### PR TITLE
resolve `Error: Tap apple/apple remote mismatch.`

### DIFF
--- a/Game Porting Toolkit Installer.miax
+++ b/Game Porting Toolkit Installer.miax
@@ -1065,7 +1065,7 @@ DMGPATHEX$MYAH$MYAH$FALSE
 
 {E3C7C0FA-6D77-1B34-CB54-81D7856F1730}
 LOGGED_COMMAND$MYAH$MYAH$FALSE
-/usr/local/bin/brew tap apple/apple http://github.com/apple/homebrew-apple
+/usr/local/bin/brew tap apple/apple http://github.com/apple/homebrew-apple --custom-remote
 {474ABB09-D7FC-8B0B-A055-8834E5FA0AB5}
 COMMAND_DESCRIPTION$MYAH$MYAH$FALSE
 Downloading and Installing Wine$NEWLINE$(this will take an extended amount of time)

--- a/Game Porting Toolkit Installer.miax.txt
+++ b/Game Porting Toolkit Installer.miax.txt
@@ -231,7 +231,7 @@ end
 if Variable WINE Equals TRUE
   Set Variable PROGRESS to 50
   Set Variable COMMAND_DESCRIPTION to Tapping Apple Homebrew$NEWLINE$apple/apple http://github.com/apple/homebrew-apple
-  Set Variable LOGGED_COMMAND to /usr/local/bin/brew tap apple/apple http://github.com/apple/homebrew-apple
+  Set Variable LOGGED_COMMAND to /usr/local/bin/brew tap apple/apple http://github.com/apple/homebrew-apple --custom-remote
   Include Script: logging (get result into variable TAP)
   if Variable TAP not Equals 0
     GoTo Label: Top


### PR DESCRIPTION
I believe this should resolve #3, #18, #24, #25

I presume the original issue is that the users have already run `brew tap` or have simply run `brew install` without having previously explicitly tapped (then newer homebrew will auto-tap).

`--custom-remote` should be flexible and also work if no tap already exists. If nothing exists it'll create the tap. If it already exists it will adjust the existing tap instead of failing.

I think a better (but bigger) change is: remove the explicit tap command altogether. But I wanted to make the smallest change possible.


(thanks for this automated installer)